### PR TITLE
🔧update(friend_links): use fwnet instead of 5050net

### DIFF
--- a/themes/particle/_config.yml
+++ b/themes/particle/_config.yml
@@ -79,7 +79,7 @@ card:
       link: https://qm.qq.com/cgi-bin/qm/qr?k=ZrLIxTgGY5P7W8SgNGfZWlLCY1kcf9Ev&jump_from=webapi&authKey=sqA+q7NjvCydLhxv5+bynRK3Jgu8DnVo6PIMenYPGrNwMNB32fd9cFFmZ3qKwpe2
   friend_links:
     🌸春樱云计算🌸: https://www.haruzakura.com
-    5050NET: https://5050net.cn/
+    𝒇𝒘𝒏𝒆𝒕: https://fw.ac.cn/
     LuocyNET: https://www.luocynet.com/
     LZTeamSE: https://www.lzteam.cloud/
 


### PR DESCRIPTION
<div align="center">

## Changes

</div>

- 在友链中使用 `𝒇𝒘𝒏𝒆𝒕` 而不是 `5050NET`，同时更换了链接

